### PR TITLE
fix(models): merge the model card with the published card -- partial runs must not clobber it

### DIFF
--- a/python/mlb_model_publish/builders.py
+++ b/python/mlb_model_publish/builders.py
@@ -53,7 +53,9 @@ def build_tag(
     """
     too_old = [s for s in seasons if s < MIN_SEASON]
     if too_old:
-        raise ValueError(f"{tag}: seasons {too_old} predate the {MIN_SEASON} Statcast floor")
+        raise ValueError(
+            f"{tag}: seasons {too_old} predate the {MIN_SEASON} Statcast floor"
+        )
 
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -73,8 +75,17 @@ def build_tag(
             stems[stem] = df.height
             paths.append(str(path))
         primary = _PRIMARY[tag]
-        results.append({"season": season, "rows": stems.get(primary, 0), "stems": stems, "paths": paths})
-        print(f"{tag}: season={season} " + " ".join(f"{k}={v}" for k, v in stems.items()))
+        results.append(
+            {
+                "season": season,
+                "rows": stems.get(primary, 0),
+                "stems": stems,
+                "paths": paths,
+            }
+        )
+        print(
+            f"{tag}: season={season} " + " ".join(f"{k}={v}" for k, v in stems.items())
+        )
     return results
 
 
@@ -143,21 +154,38 @@ _CARD_META = {
 }
 
 
-def write_card(tag: str, results: list[dict], out_dir) -> Path:
-    """Write the tag's model card next to the season parquet."""
+def write_card(
+    tag: str, results: list[dict], out_dir, *, existing: dict | None = None
+) -> Path:
+    """Write the tag's model card next to the season parquet.
+
+    Args:
+        existing: The currently-published card (fetched best-effort by the
+            CLI) -- its per-season rows are carried forward so the card always
+            reflects the full published span, not just this invocation's.
+    """
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     meta = _CARD_META[tag]
+    # Merge with the previously-published card so a partial-range invocation
+    # (the daily current-season cron, a range extension) never clobbers the
+    # other seasons' record. This run's seasons win on collision.
+    by_season: dict[int, dict] = {}
+    if existing:
+        for s, stems in (existing.get("rows_by_season") or {}).items():
+            by_season[int(s)] = stems
+    for r in results:
+        by_season[int(r["season"])] = r["stems"]
     card = {
         "tag": tag,
         "grain": meta["grain"],
         "source": meta["source"],
-        "seasons": [r["season"] for r in results],
-        "rows_by_season": {str(r["season"]): r["stems"] for r in results},
+        "seasons": sorted(by_season),
+        "rows_by_season": {str(s): by_season[s] for s in sorted(by_season)},
         "gate_anchors": meta["gates"],
         "notes": meta["notes"],
     }
     path = out_dir / f"{tag}_card.json"
     path.write_text(json.dumps(card, indent=2) + "\n", encoding="utf-8")
-    print(f"card: {path}")
+    print(f"card: {path} (seasons {card['seasons'][0]}..{card['seasons'][-1]})")
     return path

--- a/python/mlb_model_publish/cli.py
+++ b/python/mlb_model_publish/cli.py
@@ -1,9 +1,45 @@
 from __future__ import annotations
 
 import argparse
+import json
+import subprocess
 
 from .artifacts import upload_artifacts
 from .builders import build_tag, write_card
+
+
+def _fetch_existing_card(tag: str, repo: str) -> dict | None:
+    """Best-effort download of the currently-published card (None on any miss).
+
+    Feeds ``write_card``'s merge so a partial-range invocation (the daily
+    current-season cron) never clobbers the other seasons out of the card.
+    """
+    try:
+        r = subprocess.run(
+            [
+                "gh",
+                "release",
+                "download",
+                tag,
+                "-R",
+                repo,
+                "-p",
+                f"{tag}_card.json",
+                "-O",
+                "-",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if r.returncode != 0 or not r.stdout.strip():
+        return None
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return None
 
 
 def _seasons(spec: str) -> list[int]:
@@ -83,11 +119,21 @@ def _make_compute(cmd: str, args):
 def main(argv=None) -> int:
     args = build_parser().parse_args(argv)
     tag = args.tag
-    results = build_tag(_TAGS[args.cmd], _seasons(args.seasons), args.out, compute=_make_compute(args.cmd, args))
-    write_card(_TAGS[args.cmd], results, args.out)
+    results = build_tag(
+        _TAGS[args.cmd],
+        _seasons(args.seasons),
+        args.out,
+        compute=_make_compute(args.cmd, args),
+    )
+    # --build-only stays fully offline; a publishing run merges with the
+    # already-published card so partial ranges never clobber the record.
+    existing = None if args.build_only else _fetch_existing_card(tag, args.repo)
+    write_card(_TAGS[args.cmd], results, args.out, existing=existing)
     total = sum(r["rows"] for r in results)
     if args.build_only:
-        print(f"{tag}: built seasons={len(results)} rows={total} -> {args.out} (build-only)")
+        print(
+            f"{tag}: built seasons={len(results)} rows={total} -> {args.out} (build-only)"
+        )
         return 0
     res = upload_artifacts(
         args.out,
@@ -99,6 +145,8 @@ def main(argv=None) -> int:
     created = " (created release)" if res.get("created_release") else ""
     print(
         f"publish: seasons={len(results)} rows={total} uploaded={res['uploaded']} "
-        f"-> {args.repo}:{res['tag']}" + created + (" (dry-run)" if args.dry_run else "")
+        f"-> {args.repo}:{res['tag']}"
+        + created
+        + (" (dry-run)" if args.dry_run else "")
     )
     return 0

--- a/python/tests/test_mlb_model_publish.py
+++ b/python/tests/test_mlb_model_publish.py
@@ -27,7 +27,9 @@ def _fake_game_state(season: int) -> dict:
 
 
 def test_build_tag_writes_one_parquet_per_stem_per_season(tmp_path):
-    results = build_tag("mlb_game_state", [2016, 2015], tmp_path, compute=_fake_game_state)
+    results = build_tag(
+        "mlb_game_state", [2016, 2015], tmp_path, compute=_fake_game_state
+    )
 
     # processed ascending regardless of input order
     assert [r["season"] for r in results] == [2015, 2016]
@@ -53,7 +55,9 @@ def test_build_tag_refuses_an_empty_stem(tmp_path):
 
 def test_build_tag_rejects_seasons_below_the_statcast_floor(tmp_path):
     with pytest.raises(ValueError, match=str(MIN_SEASON)):
-        build_tag("mlb_game_state", [MIN_SEASON - 1], tmp_path, compute=_fake_game_state)
+        build_tag(
+            "mlb_game_state", [MIN_SEASON - 1], tmp_path, compute=_fake_game_state
+        )
 
 
 def test_card_carries_stem_rows_and_gate_anchors(tmp_path):
@@ -64,6 +68,26 @@ def test_card_carries_stem_rows_and_gate_anchors(tmp_path):
     assert card["tag"] == "mlb_game_state"
     assert card["rows_by_season"]["2020"]["mlb_wpa"] == 2
     assert card["gate_anchors"]["re24_vs_tango_max_abs_diff"] == pytest.approx(0.05)
+
+
+def test_card_merges_with_the_published_card(tmp_path):
+    """A partial-range invocation (the daily current-season cron) must carry
+    the already-published seasons forward -- this run's seasons win on
+    collision. Three clobber incidents made this a rule."""
+    results = build_tag("mlb_game_state", [2026], tmp_path, compute=_fake_game_state)
+    existing = {
+        "seasons": [2015, 2026],
+        "rows_by_season": {
+            "2015": {"mlb_re24_matrix": 24, "mlb_we_table": 5023, "mlb_wpa": 186878},
+            "2026": {"mlb_re24_matrix": 24, "mlb_we_table": 1, "mlb_wpa": 1},  # stale
+        },
+    }
+    path = write_card("mlb_game_state", results, tmp_path, existing=existing)
+
+    card = json.loads(path.read_text(encoding="utf-8"))
+    assert card["seasons"] == [2015, 2026]
+    assert card["rows_by_season"]["2015"]["mlb_wpa"] == 186878  # carried forward
+    assert card["rows_by_season"]["2026"]["mlb_wpa"] == 2  # this run wins
 
 
 def test_hitting_history_accumulates_across_seasons(tmp_path, monkeypatch):
@@ -77,20 +101,30 @@ def test_hitting_history_accumulates_across_seasons(tmp_path, monkeypatch):
     def fake_hitting(season, *, cache_dir=None, history=None):
         seen_history[season] = None if history is None else history.height
         out = {
-            "mlb_expected_stats": pl.DataFrame({"batter": [1, 2], "season": [season, season]}),
+            "mlb_expected_stats": pl.DataFrame(
+                {"batter": [1, 2], "season": [season, season]}
+            ),
             "mlb_expected_hr": pl.DataFrame({"batter": [1], "season": [season]}),
         }
         if history is not None:
-            out["mlb_batter_projection"] = pl.DataFrame({"batter": [1], "season": [season]})
+            out["mlb_batter_projection"] = pl.DataFrame(
+                {"batter": [1], "season": [season]}
+            )
         return out
 
     monkeypatch.setattr(computes, "compute_hitting", fake_hitting)
     # the accumulator age-joins each season's frame; stub it as identity so
     # the hermetic test stays offline (the join hits the statsapi people API)
     monkeypatch.setattr(computes, "age_join", lambda df: df)
-    monkeypatch.setattr(cli, "upload_artifacts", lambda *a, **k: pytest.fail("--build-only must not upload"))
+    monkeypatch.setattr(
+        cli,
+        "upload_artifacts",
+        lambda *a, **k: pytest.fail("--build-only must not upload"),
+    )
 
-    rc = main(["hitting", "--seasons", "2015:2017", "--out", str(tmp_path), "--build-only"])
+    rc = main(
+        ["hitting", "--seasons", "2015:2017", "--out", str(tmp_path), "--build-only"]
+    )
 
     assert rc == 0
     assert seen_history == {2015: None, 2016: 2, 2017: 4}


### PR DESCRIPTION
## What

The daily current-season cron's **very first scheduled run** raced the 2015:2025 backfill on `mlb_game_state` and each side clobbered the other's card (cron wrote `seasons=[2026]`, the backfill wrote 2015:2025 — the live card briefly lost 2026 either way; it has been hand-corrected to 2015:2026 in the meantime).

`write_card` now merges with the currently-published card — fetched best-effort by the CLI (`--build-only` stays fully offline) — with this run's seasons winning on collision. Third card-clobber incident across the model-publish family; structurally fixed here.

## Tests

8/8 hermetic, including the new merge test (carried-forward season preserved, stale colliding season overwritten by the current run).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published model cards now retain previously available seasons when updates cover only a partial range.
  * Updated seasons replace older entries with the latest results.
  * Card output now displays the complete published season range.

* **Bug Fixes**
  * Improved handling of unavailable historical seasons with clearer error messages.
  * Publishing continues gracefully when an existing card cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->