### PR TITLE
fix(models): bootstrap projection history from published assets on single-season runs

### DIFF
--- a/python/mlb_model_publish/cli.py
+++ b/python/mlb_model_publish/cli.py
@@ -105,7 +105,14 @@ def _make_compute(cmd: str, args):
     history_frames: list[pl.DataFrame] = []
 
     def compute(season: int):
-        history = pl.concat(history_frames[-3:]) if history_frames else None
+        # empty accumulator (a single-season cron run, or the range's first
+        # season) bootstraps history from the PUBLISHED expected-stats assets,
+        # so current-season runs still produce the projection stem
+        history = (
+            pl.concat(history_frames[-3:])
+            if history_frames
+            else computes.bootstrap_history(season)
+        )
         out = computes.compute_hitting(season, cache_dir=cache, history=history)
         if "mlb_expected_stats" in out and out["mlb_expected_stats"].height > 0:
             # age-join at accumulation time: mlb_batter_projection's history

--- a/python/mlb_model_publish/computes.py
+++ b/python/mlb_model_publish/computes.py
@@ -96,7 +96,39 @@ def compute_game_state(season: int) -> dict[str, pl.DataFrame]:
     }
 
 
-def compute_hitting(season: int, *, cache_dir=None, history: pl.DataFrame | None = None) -> dict[str, pl.DataFrame]:
+_RELEASE_DL = (
+    "https://github.com/sportsdataverse/sportsdataverse-data/releases/download"
+)
+
+
+def bootstrap_history(season: int) -> pl.DataFrame | None:
+    """Age-joined expected-stats history for ``season`` from the PUBLISHED assets.
+
+    A single-season invocation (the daily current-season cron) has no
+    in-process history accumulator, so without this the projection stem for
+    the current season would never publish. Downloads the prior three
+    seasons' ``mlb_expected_stats_{s}.parquet`` best-effort (missing seasons
+    skip) and age-joins them -- no Savant pulls.
+    """
+    import io
+    import urllib.request
+
+    frames: list[pl.DataFrame] = []
+    for s in (season - 3, season - 2, season - 1):
+        url = f"{_RELEASE_DL}/mlb_hitting_models/mlb_expected_stats_{s}.parquet"
+        try:
+            with urllib.request.urlopen(url, timeout=120) as r:
+                frames.append(pl.read_parquet(io.BytesIO(r.read())))
+        except Exception:  # noqa: BLE001 -- missing season = skip, not fail
+            continue
+    if not frames:
+        return None
+    return age_join(pl.concat(frames, how="diagonal_relaxed"))
+
+
+def compute_hitting(
+    season: int, *, cache_dir=None, history: pl.DataFrame | None = None
+) -> dict[str, pl.DataFrame]:
     """Expected stats + xHR + (history permitting) the batter projection.
 
     ``history`` is the AGE-JOINED concatenated ``mlb_expected_stats`` output of
@@ -116,8 +148,12 @@ def compute_hitting(season: int, *, cache_dir=None, history: pl.DataFrame | None
 
     puller = lambda start, end, **kw: pitches  # noqa: E731 -- injection seam
     start, end = f"{season}-01-01", f"{season}-12-01"
-    xstats = mlb_expected_stats(start, end, puller=puller).with_columns(pl.lit(season, dtype=pl.Int64).alias("season"))
-    xhr = mlb_expected_home_runs(start, end, puller=puller).with_columns(pl.lit(season, dtype=pl.Int64).alias("season"))
+    xstats = mlb_expected_stats(start, end, puller=puller).with_columns(
+        pl.lit(season, dtype=pl.Int64).alias("season")
+    )
+    xhr = mlb_expected_home_runs(start, end, puller=puller).with_columns(
+        pl.lit(season, dtype=pl.Int64).alias("season")
+    )
     out = {"mlb_expected_stats": xstats, "mlb_expected_hr": xhr}
     if history is not None and history.height > 0:
         out["mlb_batter_projection"] = mlb_batter_projection(season, history=history)
@@ -139,7 +175,10 @@ def _resolve_birthdates(batter_ids: list[int]) -> None:
         people = mlb_people(person_ids=chunk)
         if people is None or people.height == 0:
             continue
-        bd_col = next((c for c in people.columns if c.lower().replace("_", "") == "birthdate"), None)
+        bd_col = next(
+            (c for c in people.columns if c.lower().replace("_", "") == "birthdate"),
+            None,
+        )
         if bd_col is None:
             continue
         for pid, bd in zip(people["id"].to_list(), people[bd_col].to_list()):
@@ -173,7 +212,10 @@ def age_join(xstats: pl.DataFrame) -> pl.DataFrame:
                 # seasonal age = age on June 30: born after the cutoff -> one year younger
                 - (
                     (pl.col("_birth_date").dt.month() > 6)
-                    | ((pl.col("_birth_date").dt.month() == 6) & (pl.col("_birth_date").dt.day() > 30))
+                    | (
+                        (pl.col("_birth_date").dt.month() == 6)
+                        & (pl.col("_birth_date").dt.day() > 30)
+                    )
                 ).cast(pl.Int64)
             ).alias("age")
         )
@@ -197,7 +239,9 @@ def compute_fielding(season: int, *, cache_dir=None) -> dict[str, pl.DataFrame]:
         return {"mlb_oaa": pl.DataFrame()}
 
     season_col = pl.lit(season, dtype=pl.Int64).alias("season")
-    oaa = mlb_fielding_oaa(pitches.filter(pl.col("type") == "X")).with_columns(season_col)
+    oaa = mlb_fielding_oaa(pitches.filter(pl.col("type") == "X")).with_columns(
+        season_col
+    )
     framing = mlb_catcher_framing(pitches).with_columns(season_col)
     return {"mlb_oaa": oaa, "mlb_catcher_framing": framing}
 
@@ -212,7 +256,10 @@ def compute_pitching(season: int, *, cache_dir=None) -> dict[str, pl.DataFrame]:
     """
     from sportsdataverse.mlb.mlb_command_plus import mlb_command_plus
     from sportsdataverse.mlb.mlb_pitch_era import x_era
-    from sportsdataverse.mlb.mlb_pitch_features import add_sequence_features, pitch_features
+    from sportsdataverse.mlb.mlb_pitch_features import (
+        add_sequence_features,
+        pitch_features,
+    )
     from sportsdataverse.mlb.mlb_stuff_plus import mlb_stuff_plus
 
     pitches = load_season_pitches(season, cache_dir=cache_dir)
@@ -223,6 +270,10 @@ def compute_pitching(season: int, *, cache_dir=None) -> dict[str, pl.DataFrame]:
     season_col = pl.lit(season, dtype=pl.Int64).alias("season")
     return {
         "mlb_xera": x_era(feats, season).with_columns(season_col),
-        "mlb_stuff_plus": mlb_stuff_plus(feats, level="arsenal").with_columns(season_col),
-        "mlb_command_plus": mlb_command_plus(feats, level="pitcher").with_columns(season_col),
+        "mlb_stuff_plus": mlb_stuff_plus(feats, level="arsenal").with_columns(
+            season_col
+        ),
+        "mlb_command_plus": mlb_command_plus(feats, level="pitcher").with_columns(
+            season_col
+        ),
     }

--- a/python/tests/test_mlb_model_publish.py
+++ b/python/tests/test_mlb_model_publish.py
@@ -116,6 +116,8 @@ def test_hitting_history_accumulates_across_seasons(tmp_path, monkeypatch):
     # the accumulator age-joins each season's frame; stub it as identity so
     # the hermetic test stays offline (the join hits the statsapi people API)
     monkeypatch.setattr(computes, "age_join", lambda df: df)
+    # no published assets to bootstrap from in this scenario (fresh backfill)
+    monkeypatch.setattr(computes, "bootstrap_history", lambda season: None)
     monkeypatch.setattr(
         cli,
         "upload_artifacts",
@@ -131,6 +133,48 @@ def test_hitting_history_accumulates_across_seasons(tmp_path, monkeypatch):
     assert not (tmp_path / "mlb_batter_projection_2015.parquet").exists()
     assert (tmp_path / "mlb_batter_projection_2016.parquet").exists()
     assert (tmp_path / "mlb_hitting_models_card.json").exists()
+
+
+def test_single_season_run_bootstraps_history_from_published_assets(
+    tmp_path, monkeypatch
+):
+    """The daily current-season cron runs one season with an empty accumulator;
+    without the bootstrap its projection stem would never publish."""
+    import mlb_model_publish.cli as cli
+    import mlb_model_publish.computes as computes
+
+    seen_history: dict[int, int | None] = {}
+
+    def fake_hitting(season, *, cache_dir=None, history=None):
+        seen_history[season] = None if history is None else history.height
+        out = {
+            "mlb_expected_stats": pl.DataFrame({"batter": [1], "season": [season]}),
+            "mlb_expected_hr": pl.DataFrame({"batter": [1], "season": [season]}),
+        }
+        if history is not None:
+            out["mlb_batter_projection"] = pl.DataFrame(
+                {"batter": [1], "season": [season]}
+            )
+        return out
+
+    monkeypatch.setattr(computes, "compute_hitting", fake_hitting)
+    monkeypatch.setattr(computes, "age_join", lambda df: df)
+    monkeypatch.setattr(
+        computes,
+        "bootstrap_history",
+        lambda season: pl.DataFrame({"batter": [1, 2, 3], "season": [season - 1] * 3}),
+    )
+    monkeypatch.setattr(
+        cli,
+        "upload_artifacts",
+        lambda *a, **k: pytest.fail("--build-only must not upload"),
+    )
+
+    rc = main(["hitting", "--seasons", "2026", "--out", str(tmp_path), "--build-only"])
+
+    assert rc == 0
+    assert seen_history == {2026: 3}  # the bootstrapped frame reached the compute
+    assert (tmp_path / "mlb_batter_projection_2026.parquet").exists()
 
 
 def test_upload_pattern_selects_stems_and_card(tmp_path):


### PR DESCRIPTION
The daily current-season cron runs one season with an empty in-process
accumulator, so mlb_batter_projection_{current} would never publish (the
cron's first 2026 run silently skipped the stem). An empty accumulator
now bootstraps the prior three seasons' published mlb_expected_stats
assets (best-effort, no Savant pulls) and age-joins them, so
single-season runs produce the projection too. 9 hermetic tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hitting model builds can now initialize historical data from previously published prior-season assets.
  * Single-season builds produce the expected batter projection output when historical data is available.

* **Bug Fixes**
  * Improved handling of hitting builds when no accumulated history exists.

* **Tests**
  * Added coverage for history bootstrapping and build-only output generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->