### PR TITLE
feat(models): commit the mlb data tree + ship csv/rds/parquet per release

### DIFF
--- a/.github/workflows/mlb_models_cron.yml
+++ b/.github/workflows/mlb_models_cron.yml
@@ -27,7 +27,8 @@ on:
     - cron: '30 10 * 4-10 *'
 
 permissions:
-  contents: read
+  # the job commits the mlb/ data tree back to this repo after publishing
+  contents: write
 
 env:
   PUBLISH_REPO: sportsdataverse/sportsdataverse-data
@@ -113,3 +114,20 @@ jobs:
           uv run --no-sync python -m mlb_model_publish pitching \
             --seasons "$SEASONS" --repo "$PUBLISH_REPO" \
             ${{ inputs.dry_run && '--dry-run' || '' }}
+
+      # The builders write into the committed mlb/{dataset}/{format}/ tree;
+      # mirror it back to the repo (the family tree+releases convention). The
+      # (Start: End:) commit-subject shape is the repo's load-bearing format.
+      - name: Commit the mlb data tree
+        if: ${{ !inputs.dry_run }}
+        working-directory: .
+        run: |
+          git config user.name "Github Action"
+          git config user.email "action@github.com"
+          git add mlb
+          if git diff --staged --quiet; then
+            echo "no tree changes"
+          else
+            git commit -m "MLB Models update (Start: ${SEASONS%%:*} End: ${SEASONS##*:})"
+            git push
+          fi

--- a/python/mlb_model_publish/builders.py
+++ b/python/mlb_model_publish/builders.py
@@ -27,6 +27,53 @@ _PRIMARY = {
 }
 
 
+#: the committed data tree at the repo root -- absolute, so a CLI run from
+#: python/ can never silently write a python/mlb_models/ shadow tree (the
+#: wbb_data_build --base lesson). Layout: mlb_models/{tag}/{format}/{stem}_{season}.{ext}
+REPO_TREE = Path(__file__).resolve().parents[2] / "mlb"
+
+
+def _write_stem(df, out_dir: Path, stem: str, season: int) -> list[str]:
+    """Write one stem-season in the family's three formats (parquet+csv+rds).
+
+    The rds is written natively (sdv-py ``write_rds``) with baseballr's S3
+    class chain + attribute pair so R consumers get the family print method;
+    unsigned columns are cast to Int64 for the rds only (R has no unsigned).
+    """
+    from datetime import datetime, timezone
+
+    import polars as pl
+    from sportsdataverse._rds import write_rds
+
+    paths: list[str] = []
+    for fmt in ("parquet", "csv", "rds"):
+        d = out_dir / fmt
+        d.mkdir(parents=True, exist_ok=True)
+        path = d / f"{stem}_{season}.{fmt}"
+        if fmt == "parquet":
+            df.write_parquet(path)
+        elif fmt == "csv":
+            df.write_csv(path)
+        else:
+            rds_df = df.with_columns(
+                pl.col(c).cast(pl.Int64)
+                for c, t in df.schema.items()
+                if t in (pl.UInt32, pl.UInt64, pl.UInt16, pl.UInt8)
+            )
+            stamped = datetime.now(timezone.utc)
+            write_rds(
+                rds_df,
+                path,
+                cls=["baseballr_data", "tbl_df", "tbl", "data.table", "data.frame"],
+                attributes={
+                    "baseballr_timestamp": stamped,
+                    "baseballr_type": f"MLB {stem} data",
+                },
+            )
+        paths.append(str(path))
+    return paths
+
+
 def build_tag(
     tag: str,
     seasons: list[int],
@@ -70,10 +117,8 @@ def build_tag(
         stems: dict[str, int] = {}
         paths: list[str] = []
         for stem, df in frames.items():
-            path = out_dir / f"{stem}_{season}.parquet"
-            df.write_parquet(path)
+            paths.extend(_write_stem(df, out_dir, stem, season))
             stems[stem] = df.height
-            paths.append(str(path))
         primary = _PRIMARY[tag]
         results.append(
             {

--- a/python/mlb_model_publish/cli.py
+++ b/python/mlb_model_publish/cli.py
@@ -5,7 +5,7 @@ import json
 import subprocess
 
 from .artifacts import upload_artifacts
-from .builders import build_tag, write_card
+from .builders import REPO_TREE, build_tag, write_card
 
 
 def _fetch_existing_card(tag: str, repo: str) -> dict | None:
@@ -68,7 +68,10 @@ def build_parser() -> argparse.ArgumentParser:
             required=True,
             help="a season (2024) or an inclusive range (2015:2025)",
         )
-        p.add_argument("--out", default=f"out/{tag}")
+        # default = the COMMITTED repo tree (absolute), so builds land in
+        # mlb/{dataset}/{format}/ (family layout, e.g. mlb/game_state/parquet/)
+        # and the cron's commit step picks them up
+        p.add_argument("--out", default=str(REPO_TREE / tag.removeprefix("mlb_")))
         p.add_argument("--tag", default=tag)
         p.add_argument("--repo", default="sportsdataverse/sportsdataverse-data")
         if cmd != "game-state":
@@ -146,7 +149,7 @@ def main(argv=None) -> int:
         args.out,
         tag,
         args.repo,
-        pattern="mlb_*.*",
+        pattern="**/mlb_*.*",  # reaches the parquet/csv/rds format subdirs + the card
         dry_run=args.dry_run,
     )
     created = " (created release)" if res.get("created_release") else ""

--- a/python/tests/test_mlb_model_publish.py
+++ b/python/tests/test_mlb_model_publish.py
@@ -1,9 +1,9 @@
-"""Hermetic tests for the mlb_model_publish builders.
+"""Hermetic tests for the mlb model-publish builders.
 
-Compute seams are stubbed -- these assert orchestration (multi-stem writes,
-season ordering, empty-stem refusal, floor, cards, per-file upload, the
-hitting history accumulation) -- not the model math (gated in sdv-py's MLB
-oracle suites).
+Compute seams are stubbed -- these assert orchestration (three-format
+tree writes, season ordering, empty-stem refusal, floor, merged cards,
+per-file upload, the hitting history accumulation + bootstrap) -- not the
+model math (gated in sdv-py's MLB oracle suites).
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ def _fake_game_state(season: int) -> dict:
     }
 
 
-def test_build_tag_writes_one_parquet_per_stem_per_season(tmp_path):
+def test_build_tag_writes_three_formats_per_stem_per_season(tmp_path):
     results = build_tag(
         "mlb_game_state", [2016, 2015], tmp_path, compute=_fake_game_state
     )
@@ -35,9 +35,11 @@ def test_build_tag_writes_one_parquet_per_stem_per_season(tmp_path):
     assert [r["season"] for r in results] == [2015, 2016]
     for season in (2015, 2016):
         for stem in ("mlb_re24_matrix", "mlb_we_table", "mlb_wpa"):
-            path = tmp_path / f"{stem}_{season}.parquet"
-            assert path.exists()
-            assert pl.read_parquet(path)["season"].unique().to_list() == [season]
+            # the family tree convention: parquet + csv + rds per stem-season
+            for fmt in ("parquet", "csv", "rds"):
+                assert (tmp_path / fmt / f"{stem}_{season}.{fmt}").exists(), (stem, fmt)
+            frame = pl.read_parquet(tmp_path / "parquet" / f"{stem}_{season}.parquet")
+            assert frame["season"].unique().to_list() == [season]
     assert results[0]["rows"] == 1  # primary stem = re24 matrix
 
 
@@ -50,7 +52,7 @@ def test_build_tag_refuses_an_empty_stem(tmp_path):
     with pytest.raises(ValueError, match="mlb_wpa"):
         build_tag("mlb_game_state", [2020], tmp_path, compute=compute)
 
-    assert not (tmp_path / "mlb_wpa_2020.parquet").exists()
+    assert not (tmp_path / "parquet" / "mlb_wpa_2020.parquet").exists()
 
 
 def test_build_tag_rejects_seasons_below_the_statcast_floor(tmp_path):
@@ -130,8 +132,8 @@ def test_hitting_history_accumulates_across_seasons(tmp_path, monkeypatch):
 
     assert rc == 0
     assert seen_history == {2015: None, 2016: 2, 2017: 4}
-    assert not (tmp_path / "mlb_batter_projection_2015.parquet").exists()
-    assert (tmp_path / "mlb_batter_projection_2016.parquet").exists()
+    assert not (tmp_path / "parquet" / "mlb_batter_projection_2015.parquet").exists()
+    assert (tmp_path / "parquet" / "mlb_batter_projection_2016.parquet").exists()
     assert (tmp_path / "mlb_hitting_models_card.json").exists()
 
 
@@ -174,11 +176,13 @@ def test_single_season_run_bootstraps_history_from_published_assets(
 
     assert rc == 0
     assert seen_history == {2026: 3}  # the bootstrapped frame reached the compute
-    assert (tmp_path / "mlb_batter_projection_2026.parquet").exists()
+    assert (tmp_path / "parquet" / "mlb_batter_projection_2026.parquet").exists()
 
 
-def test_upload_pattern_selects_stems_and_card(tmp_path):
-    (tmp_path / "mlb_re24_matrix_2020.parquet").write_bytes(b"x")
+def test_upload_pattern_reaches_format_subdirs_and_card(tmp_path):
+    for fmt in ("parquet", "csv", "rds"):
+        (tmp_path / fmt).mkdir()
+        (tmp_path / fmt / f"mlb_re24_matrix_2020.{fmt}").write_bytes(b"x")
     (tmp_path / "mlb_game_state_card.json").write_text("{}")
     (tmp_path / "unrelated.txt").write_text("no")
 
@@ -187,14 +191,19 @@ def test_upload_pattern_selects_stems_and_card(tmp_path):
         tmp_path,
         "mlb_game_state",
         "sportsdataverse/sportsdataverse-data",
-        pattern="mlb_*.*",
+        pattern="**/mlb_*.*",
         runner=lambda args: calls.append(args),
         exists_check=lambda tag, repo: True,
     )
 
     names = sorted(p.rsplit("\\", 1)[-1].rsplit("/", 1)[-1] for p in res["files"])
-    assert names == ["mlb_game_state_card.json", "mlb_re24_matrix_2020.parquet"]
-    assert res["uploaded"] == 2
+    assert names == [
+        "mlb_game_state_card.json",
+        "mlb_re24_matrix_2020.csv",
+        "mlb_re24_matrix_2020.parquet",
+        "mlb_re24_matrix_2020.rds",
+    ]
+    assert res["uploaded"] == 4
     assert all("--clobber" in c for c in calls)
 
 


### PR DESCRIPTION
Family tree+releases convention, per review: builders now write every
stem-season in all three formats into the COMMITTED mlb/{dataset}/{format}/
tree (absolute path -- the wbb CWD-relative --base lesson), the rds
natively via sdv-py write_rds with baseballr's S3 class chain +
baseballr_timestamp/_type attributes (unsigned cols cast to Int64 for R),
uploads reach the format subdirs (**/mlb_*.*), and the cron gains a
contents:write tree-commit step using the load-bearing
'MLB Models update (Start: Y End: Y)' subject. 9 hermetic tests.

One-time migration of the already-published parquet-only assets to the
tree + csv/rds follows as a data-op.
