### PR TITLE
chore(models): commit only parquet in the mlb data tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 __pycache__/
 *.pyc
 .omc/
+
+# model-dataset trees commit parquet only; csv/rds are release-asset staging
+mlb/*/csv/
+mlb/*/rds/


### PR DESCRIPTION
csv + rds still build and upload to the releases (all three formats per
release); the committed tree keeps just the compact parquet -- the csv/rds
staging dirs are gitignored so the cron's 'git add mlb' skips them.
