### PR TITLE
ci(tests): sparse-checkout models/ so the registry and manifest gates can read their inputs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
           sparse-checkout: |
             python
             tests
+            models
             scripts
             pyproject.toml
             uv.lock


### PR DESCRIPTION
The Track-C registry/manifest gates added 2026-09-01 read `models/REGISTRY.md` and `models/manifest.yaml`, but the `tests` job's sparse checkout never included `models/` (nor `.github/` where a test asserts on the workflow files) -- red on every push since, including the latest on `main`. One-line sparse-list fix, same as sportsdataverse/nfl-data#27; the large committed data trees the sparse checkout exists to avoid stay excluded. Found by the 2026-09-01 data & modeling stocktake (ClaudeCowork `notes/2026-09-01-data-model-stocktake/`, ledger L44).

## Summary by Sourcery

Ensure the tests workflow can run registry and manifest gates by checking out the models inputs it requires.

Bug Fixes:
- Fix the tests workflow by including the models directory in sparse checkouts so registry and manifest validation can access their required inputs.

CI:
- Update the tests CI sparse-checkout configuration to include models while continuing to exclude large data trees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated test setup to include the required models directory, helping ensure test runs have access to all necessary project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->