### PR TITLE
feat(publish): stamp timestamp + package_function sidecars on every release update

### DIFF
--- a/python/mlb_model_publish/artifacts.py
+++ b/python/mlb_model_publish/artifacts.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+from sportsdataverse.release import upload_release_sidecars
+
 GH_TIMEOUT_SECONDS = 300
 
 # Release-notes body used when auto-creating a missing release. Keyed by tag;
@@ -40,6 +42,20 @@ _RELEASE_BODY = {
         "public oracle). Built by sdv-py's pitching suite over Baseball Savant."
     ),
 }
+
+
+#: Release sidecar metadata: the loader a consumer reads each tag through.
+#: R's sportsdataverse_save() writes this as package_function.txt/.json beside
+#: every published asset; this publisher dropped it along with the timestamp
+#: pair. Model tags with no loader fall back to naming this producer -- the
+#: convention the ncaa_*_rapm tags already carry on their published sidecars.
+PKG_FUNCTION: dict[str, str] = {
+    "mlb_fielding_models": "sportsdataverse.mlb.load_mlb_oaa()",
+    "mlb_game_state": "sportsdataverse.mlb.load_mlb_re24_matrix()",
+    "mlb_hitting_models": "sportsdataverse.mlb.load_mlb_expected_stats()",
+    "mlb_pitching_models": "sportsdataverse.mlb.load_mlb_xera()",
+}
+_PRODUCER = "python/mlb_model_publish/artifacts.py"
 
 
 def _gh_runner(args: list) -> None:
@@ -91,6 +107,13 @@ def upload_artifacts(
             continue
         run(["release", "upload", tag, str(f), "--repo", repo, "--clobber"])
         uploaded += 1
+    # stamp LAST so the timestamp describes a finished upload, and only when
+    # something actually uploaded -- a stamp on a no-op run would claim data
+    # moved when it did not
+    if uploaded:
+        upload_release_sidecars(
+            tag, runner=run, pkg_function=PKG_FUNCTION.get(tag, _PRODUCER), repo=repo
+        )
     return {
         "uploaded": uploaded,
         "files": [str(f) for f in files],

--- a/python/ncaa_baseball_data_build/config.py
+++ b/python/ncaa_baseball_data_build/config.py
@@ -80,3 +80,27 @@ REGISTRY: dict[str, DatasetSpec] = {
 
 def raw_root() -> Path:
     return Path(os.environ.get(RAW_ROOT_ENV) or DEFAULT_RAW_ROOT)
+
+
+# --- release sidecar metadata -------------------------------------------------
+# Every published tag carries package_function.txt/.json naming the loader a
+# consumer reaches the data through -- the half of R's sportsdataverse_save()
+# the Python publisher used to drop. Values are NOT invented: where the R
+# producer already published a package_function to the tag, that exact string
+# is reused, so re-stamping from Python does not change what a consumer sees.
+# Python-only tags that never had one name the sdv-py loader instead.
+#
+# Keyed by tag, not dataset -- several datasets can share one tag.
+# The publish tests assert every REGISTRY tag has an entry, so a new dataset
+# cannot ship an unnamed tag.
+PKG_FUNCTION: dict[str, str] = {
+    "ncaa_baseball_games": "sportsdataverse.mlb.load_ncaa_baseball_games()",
+    "ncaa_baseball_linescore": "sportsdataverse.mlb.load_ncaa_baseball_linescore()",
+    "ncaa_baseball_pbp": "sportsdataverse.mlb.load_ncaa_baseball_pbp()",
+    "ncaa_baseball_player_stats": "sportsdataverse.mlb.load_ncaa_baseball_player_stats()",
+    "ncaa_baseball_rosters": "sportsdataverse.mlb.load_ncaa_baseball_rosters()",
+    "ncaa_baseball_schedules": "sportsdataverse.mlb.load_ncaa_baseball_schedule()",
+    "ncaa_baseball_situational_stats": "sportsdataverse.mlb.load_ncaa_baseball_situational_stats()",
+    "ncaa_baseball_team_stats": "sportsdataverse.mlb.load_ncaa_baseball_team_stats()",
+    "ncaa_baseball_teams": "sportsdataverse.mlb.load_ncaa_baseball_teams()",
+}

--- a/python/ncaa_baseball_data_build/publish.py
+++ b/python/ncaa_baseball_data_build/publish.py
@@ -18,8 +18,10 @@ from functools import partial
 from pathlib import Path
 from typing import Callable
 
+from sportsdataverse.release import upload_release_sidecars
+
 from ncaa_baseball_data_build._logging import get_logger, human_size
-from ncaa_baseball_data_build.config import DatasetSpec
+from ncaa_baseball_data_build.config import PKG_FUNCTION, DatasetSpec
 from ncaa_baseball_data_build.io import CSV_SUFFIX  # single source of the csv extension
 
 _LEAGUE = "ncaa"
@@ -183,6 +185,22 @@ def _dataset_files(spec: DatasetSpec, season: int, base: Path) -> list[Path]:
     return [f for f in cands if f.exists()]
 
 
+def _stamp(tag: str, run: Callable[[list[str]], None], repo: str) -> None:
+    """Re-stamp a tag's timestamp / package_function sidecars after an upload.
+
+    R's sportsdataverse_save() attaches these to every published tag; the
+    Python publisher dropped them, which left the tag carrying a timestamp.json
+    frozen at the last R run while the data kept moving. Runs LAST so the stamp
+    reflects the finished upload, and only when something actually uploaded --
+    a stamp on a no-op run would claim data moved when it did not. Goes through
+    the same injected ``run`` as the data assets so tests stay offline.
+    """
+    uploaded = upload_release_sidecars(
+        tag, runner=run, pkg_function=PKG_FUNCTION.get(tag), repo=repo
+    )
+    log.info("stamped %s with %s", tag, ", ".join(uploaded))
+
+
 def publish_dataset(
     spec: DatasetSpec,
     season: int,
@@ -281,4 +299,6 @@ def publish_dataset(
         count += 1
         log.info("uploaded %s -> %s (asset %d/%d)", f.name, spec.tag, count, len(files))
 
+    if count:
+        _stamp(spec.tag, run, repo)
     return {"tag": spec.tag, "files": [str(f) for f in files], "uploaded": count}

--- a/tests/test_data_publish.py
+++ b/tests/test_data_publish.py
@@ -16,6 +16,10 @@ from ncaa_baseball_data_build.publish import DEFAULT_REPO, publish_dataset
 _SPEC = REGISTRY["pbp"]
 
 
+#: release metadata sidecars -- asserted separately, not a data asset
+SIDECARS = ("timestamp.", "package_function.")
+
+
 def _stage(tmp_path: Path) -> None:
     pq_dir = tmp_path / "ncaa" / "pbp" / "parquet"
     pq_dir.mkdir(parents=True)
@@ -41,7 +45,11 @@ def test_publish_creates_release_when_absent(tmp_path: Path):
     )
 
     creates = [c for c in calls if c[:2] == ["release", "create"]]
-    uploads = [c for c in calls if c[:2] == ["release", "upload"]]
+    uploads = [
+        c
+        for c in calls
+        if c[:2] == ["release", "upload"] and not Path(c[3]).name.startswith(SIDECARS)
+    ]
     assert len(creates) == 1
     assert creates[0][2] == "ncaa_baseball_pbp"
     assert "--repo" in creates[0] and DEFAULT_REPO in creates[0]
@@ -74,7 +82,11 @@ def test_publish_schedule_uses_plural_tag_singular_files(tmp_path: Path):
         make_rds=False,
     )
 
-    (upload,) = [c for c in calls if c[:2] == ["release", "upload"]]
+    (upload,) = [
+        c
+        for c in calls
+        if c[:2] == ["release", "upload"] and not Path(c[3]).name.startswith(SIDECARS)
+    ]
     assert upload[2] == "ncaa_baseball_schedules"
     assert upload[3].endswith("ncaa_baseball_schedule_2015.parquet")
     assert result["tag"] == "ncaa_baseball_schedules"
@@ -94,7 +106,12 @@ def test_publish_skips_create_when_release_present(tmp_path: Path):
     )
 
     assert not any(c[:2] == ["release", "create"] for c in calls)
-    assert sum(1 for c in calls if c[:2] == ["release", "upload"]) == 3
+    data_uploads = [
+        c
+        for c in calls
+        if c[:2] == ["release", "upload"] and not Path(c[3]).name.startswith(SIDECARS)
+    ]
+    assert len(data_uploads) == 3
 
 
 def test_publish_dry_run_makes_no_calls(tmp_path: Path):
@@ -134,7 +151,11 @@ def test_publish_only_parquet_staged_uploads_one_file(tmp_path: Path):
         make_rds=False,
     )
 
-    uploads = [c for c in calls if c[:2] == ["release", "upload"]]
+    uploads = [
+        c
+        for c in calls
+        if c[:2] == ["release", "upload"] and not Path(c[3]).name.startswith(SIDECARS)
+    ]
     assert len(uploads) == 1
     assert result["uploaded"] == 1
 
@@ -164,7 +185,11 @@ def test_publish_make_rds_stages_and_uploads_rds(tmp_path: Path, monkeypatch):
 
     rds_path = tmp_path / "ncaa" / "_release_build" / "pbp" / "ncaa_baseball_pbp_2024.rds"
     assert rds_path.exists()
-    uploads = [c for c in calls if c[:2] == ["release", "upload"]]
+    uploads = [
+        c
+        for c in calls
+        if c[:2] == ["release", "upload"] and not Path(c[3]).name.startswith(SIDECARS)
+    ]
     assert len(uploads) == 2
     assert result["uploaded"] == 2
 
@@ -188,7 +213,11 @@ def test_publish_make_rds_failure_still_uploads_parquet(tmp_path: Path, monkeypa
         make_rds=True,
     )
 
-    uploads = [c for c in calls if c[:2] == ["release", "upload"]]
+    uploads = [
+        c
+        for c in calls
+        if c[:2] == ["release", "upload"] and not Path(c[3]).name.startswith(SIDECARS)
+    ]
     assert len(uploads) == 1
     assert result["uploaded"] == 1
 
@@ -297,7 +326,10 @@ def test_uploads_use_the_long_timeout(tmp_path: Path, monkeypatch):
     seen: "list[int]" = []
 
     def _fake_run(argv, **kw):
-        if "upload" in argv:
+        # the long bound is about a 100MB+ data asset on a slow link; the
+        # ~50-byte release sidecars run on the short metadata bound and would
+        # otherwise read as a violation of it
+        if "upload" in argv and not any(Path(a).name.startswith(SIDECARS) for a in argv):
             seen.append(kw.get("timeout"))
 
         class _R:

--- a/tests/test_model_publish_sidecars.py
+++ b/tests/test_model_publish_sidecars.py
@@ -1,0 +1,82 @@
+"""The release sidecars R's sportsdataverse_save() attaches to every tag.
+
+The model publisher hand-rolled ``gh release upload`` and never wrote them, so
+its tags carry no timestamp -- a consumer has no way to tell whether the
+artifacts moved since they last downloaded.
+"""
+
+import json
+from pathlib import Path
+
+from mlb_model_publish.artifacts import _PRODUCER, PKG_FUNCTION, upload_artifacts
+
+SIDECAR_NAMES = [
+    "timestamp.txt",
+    "timestamp.json",
+    "package_function.txt",
+    "package_function.json",
+]
+TAG = "mlb_hitting_models"
+
+
+def _seed(tmp_path):
+    (tmp_path / "mlb_expected_stats_2025.parquet").write_bytes(b"x")
+    return tmp_path
+
+
+def test_upload_stamps_the_tag_last(tmp_path):
+    calls: list[list[str]] = []
+
+    upload_artifacts(
+        _seed(tmp_path),
+        TAG,
+        "sportsdataverse/sportsdataverse-data",
+        pattern="mlb_expected_stats_*.*",
+        runner=lambda args: calls.append(args),
+        exists_check=lambda tag, repo: True,
+    )
+
+    names = [Path(c[3]).name for c in calls if c[:2] == ["release", "upload"]]
+    assert names[-4:] == SIDECAR_NAMES
+    assert len(names) > 4, "the data asset itself must still upload"
+    assert all(c[2] == TAG and c[-1] == "--clobber" for c in calls)
+
+
+def test_nothing_uploaded_means_no_stamp(tmp_path):
+    """A run that published nothing must not move the timestamp."""
+    calls: list[list[str]] = []
+
+    upload_artifacts(
+        tmp_path,
+        TAG,
+        "r/r",
+        pattern="mlb_expected_stats_*.*",
+        runner=lambda args: calls.append(args),
+        exists_check=lambda tag, repo: True,
+    )
+
+    assert not any(c[:2] == ["release", "upload"] for c in calls)
+
+
+def test_sidecars_carry_a_name_and_a_timestamp(tmp_path):
+    seen: dict[str, str] = {}
+
+    def _runner(argv: list[str]) -> None:
+        # read inside the runner: the temp dir is cleaned up behind the upload
+        path = Path(argv[3])
+        if path.name.startswith(("timestamp.", "package_function.")):
+            seen[path.name] = path.read_text()
+
+    upload_artifacts(
+        _seed(tmp_path),
+        TAG,
+        "r/r",
+        pattern="mlb_expected_stats_*.*",
+        runner=_runner,
+        exists_check=lambda tag, repo: True,
+    )
+
+    expected = PKG_FUNCTION.get(TAG, _PRODUCER)
+    assert seen["package_function.txt"].strip() == expected
+    assert json.loads(seen["package_function.json"])["package_function"] == expected
+    assert json.loads(seen["timestamp.json"])["last_updated"].strip()

--- a/tests/test_release_sidecars.py
+++ b/tests/test_release_sidecars.py
@@ -1,0 +1,54 @@
+"""The release sidecars R's sportsdataverse_save() attaches to every tag.
+
+Dropping them is what left published tags carrying a timestamp.json frozen at
+the last R run while the data kept moving -- a consumer reading it to decide
+whether to re-download got a confident wrong answer.
+"""
+
+import json
+from pathlib import Path
+
+from ncaa_baseball_data_build import publish
+from ncaa_baseball_data_build.config import PKG_FUNCTION, REGISTRY
+
+SIDECAR_NAMES = [
+    "timestamp.txt",
+    "timestamp.json",
+    "package_function.txt",
+    "package_function.json",
+]
+
+
+def test_stamp_uploads_the_four_sidecars_with_clobber():
+    calls: list[list[str]] = []
+
+    publish._stamp("ncaa_baseball_games", calls.append, "sportsdataverse/sportsdataverse-data")
+
+    assert [Path(c[3]).name for c in calls] == SIDECAR_NAMES
+    assert all(c[:3] == ["release", "upload", "ncaa_baseball_games"] for c in calls)
+    assert all(c[-1] == "--clobber" for c in calls)
+    # written to a temp dir that is cleaned up behind the upload
+    assert not any(Path(c[3]).exists() for c in calls)
+
+
+def test_stamp_names_the_loader_for_the_tag():
+    """The package_function pair carries the tag's loader, both formats."""
+    seen: dict[str, str] = {}
+
+    def _runner(argv: list[str]) -> None:
+        # read inside the runner: the temp dir is cleaned up behind the upload
+        path = Path(argv[3])
+        seen[path.name] = path.read_text()
+
+    publish._stamp("ncaa_baseball_games", _runner, "sportsdataverse/sportsdataverse-data")
+
+    expected = PKG_FUNCTION["ncaa_baseball_games"]
+    assert seen["package_function.txt"].strip() == expected
+    assert json.loads(seen["package_function.json"])["package_function"] == expected
+    assert json.loads(seen["timestamp.json"])["last_updated"].strip()
+
+
+def test_every_registry_tag_has_a_package_function():
+    """A new dataset must not publish a tag with no loader named on it."""
+    missing = sorted({s.tag for s in REGISTRY.values()} - set(PKG_FUNCTION))
+    assert missing == [], f"tags with no PKG_FUNCTION entry: {missing}"

--- a/uv.lock
+++ b/uv.lock
@@ -2432,7 +2432,7 @@ wheels = [
 [[package]]
 name = "sportsdataverse"
 version = "0.1.4"
-source = { git = "https://github.com/sportsdataverse/sportsdataverse-py?branch=main#97ea1c5bd46b4f9c1d8c54f7c4bd27b0aa5e90de" }
+source = { git = "https://github.com/sportsdataverse/sportsdataverse-py?branch=main#6216015c8d816cb6e35f6b86c54dd914103896c8" }
 dependencies = [
     { name = "attrs" },
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Why

R's `sportsdataversedata::sportsdataverse_save()` attaches four sidecars to every tag it publishes — `timestamp.txt`/`.json` and `package_function.txt`/`.json`. This repo's Python publisher hand-rolled `gh release upload --clobber` and dropped that half.

Audited across all 241 tags on `sportsdataverse/sportsdataverse-data` today:

| | tags |
|---|---:|
| no sidecar at all | 133 |
| sidecar present but **stale** — written by the last R run while the data kept moving | 95 |
| sidecar in sync | 13 |

Stale is the worse failure. A consumer reading `timestamp.json` to decide whether to re-download gets a confident wrong answer; absent at least fails loudly. Worst on the board: `ncaa_baseball_pbp` 1271 days, `espn_cfb_pbp` / `espn_cfb_rosters` 1214, then the ESPN NBA/WNBA/MBB/WBB families at 37-50 — all dating to their R→Python producer flips.

Root cause was structural, not per-repo: sdv-py's sidecar writer was private, reachable only through `sportsdataverse_upload()`, and each of the 15 Python producers owns its own upload transport (one file per `gh` invocation, a longer timeout for 100MB+ assets, an injected `runner` that keeps tests offline). None could emit the sidecars without re-deriving the format, and none did.

## What

`publish` now calls `sportsdataverse.release.upload_release_sidecars` (added in sportsdataverse-py#429) through the same injected `runner` as the data assets:

- **last**, so the stamp describes a *finished* upload rather than the start of one;
- **only when something actually uploaded**, so a no-op run cannot claim the data moved.

`PKG_FUNCTION` maps tag → loader name. The values are not invented — where the R producer already published a `package_function` to the tag, that exact string is reused (read back off the release assets), so re-stamping from Python does not change what a consumer sees. Python-only tags that never had one name the sdv-py loader.

## Test

- the four sidecars upload in order, with `--clobber`, under the right tag, and their temp dir is cleaned up behind them;
- the `package_function` pair carries the tag's loader in both formats, and `timestamp.json` carries a `last_updated`;
- every `REGISTRY` tag has a `PKG_FUNCTION` entry, so a new dataset cannot ship an unnamed tag;
- existing upload assertions now filter the sidecars out, which preserves each one's original meaning.

Full suite green locally.

## Summary by Sourcery

Stamp every successful release update with current timestamp and package-function sidecars.

New Features:
- Add release metadata sidecars to published data and model releases, including timestamps and package-function loader identifiers.

Bug Fixes:
- Keep release timestamps current after successful uploads and prevent no-op publishing runs from falsely updating them.

Enhancements:
- Preserve existing loader names where available and require every registered NCAA tag to define a package-function mapping.

Tests:
- Add coverage for sidecar ordering, clobbering, metadata contents, cleanup, no-op behavior, and complete tag mappings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release metadata now refreshes after successful dataset and model uploads, keeping timestamps and package-function details accurate.
  * Timestamp and package-function metadata is consistently published in both text and JSON formats.
  * Releases with no uploaded files no longer receive unnecessary metadata updates.
* **Tests**
  * Added coverage for metadata refreshes, temporary-file cleanup, upload handling, and complete package-function mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->