### PR TITLE
fix(ncaa): do not release a payload dataset that built zero rows

### DIFF
--- a/python/ncaa_baseball_data_build/cli.py
+++ b/python/ncaa_baseball_data_build/cli.py
@@ -157,6 +157,18 @@ def _build(args: argparse.Namespace) -> int:
     for name in PAYLOAD_DATASETS:
         spec = REGISTRY[name]
         _finish(frames[name], spec, args.season, base, release=release)
+        if release and not frames[name].height:
+            # The guard above only proves the season has PARSED payloads, which is a
+            # statement about `games`. The box-score datasets are capture-era only
+            # (2024+), so a legacy season satisfies that guard and still yields zero
+            # rows here -- publishing it ships a schema-only asset that makes the tag
+            # advertise coverage it does not have. Build it locally, do not release it.
+            log.warning(
+                "not publishing %s %s: 0 rows (outside this dataset's capture era)",
+                name,
+                args.season,
+            )
+            continue
         if release:
             _publish(spec, args.season, base, args.dry_run)
     _write_qa(frames["qa"], args.season, base)

--- a/tests/test_data_build.py
+++ b/tests/test_data_build.py
@@ -267,3 +267,48 @@ def test_schedule_prefers_capture_master(tree: Path, tmp_path: Path) -> None:
 def test_missing_season_fails_loudly(tree: Path, tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError):
         _build(tmp_path / "out", tree, 2013, dataset="pbp")
+
+
+def test_legacy_season_does_not_publish_the_empty_capture_only_families(
+    tree: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A legacy season must BUILD the capture-era families empty (above) but must
+    not RELEASE them.
+
+    The season-level guard only checks ``frames["games"]``, which is populated for
+    legacy seasons, so every payload dataset used to publish alongside it — shipping
+    schema-only assets that made each tag advertise coverage it does not have (28 of
+    them across player_stats/team_stats/situational_stats/linescore, 2017-2023).
+    """
+    from ncaa_baseball_data_build import cli
+
+    published: list[str] = []
+    monkeypatch.setattr(
+        cli, "_publish", lambda spec, season, base, dry_run: published.append(spec.name)
+    )
+
+    assert (
+        cli.main(
+            [
+                "build",
+                "--dataset",
+                "all",
+                "--season",
+                str(LEGACY_SEASON),
+                "--base",
+                str(tmp_path / "out"),
+                "--raw-root",
+                str(tree),
+                "--dry-run",
+            ]
+        )
+        == 0
+    )
+
+    for empty_family in ("linescore", "team_stats", "player_stats", "situational_stats"):
+        assert empty_family not in published, (
+            f"{empty_family} has 0 rows for {LEGACY_SEASON} and must not be released"
+        )
+    # the populated families still publish
+    assert "games" in published
+    assert "pbp" in published


### PR DESCRIPTION
Found while adding the `ncaa_baseball` loaders in sportsdataverse/sportsdataverse-py#432, and it answers ledger L54.

## The defect

Four `ncaa_baseball_*` tags carry **28 schema-only assets**: `player_stats`, `team_stats`, `situational_stats` and `linescore` for 2017-2023. Each is byte-identical across seasons — 700 / 1,220 / 700 / 1,475 bytes — and reads back as **0 rows** with the correct column schema. Real data starts in 2024.

That is not a failed backfill. `config.py` documents *"legacy R era 2012-2023, capture era 2024+"* and those four datasets are labelled `(capture era)` in the REGISTRY — the per-game box payloads genuinely were not captured before 2024.

The bug is that we **publish** them anyway. The guard in `_build` is season-level:

```python
if not frames["games"].height:
    raise FileNotFoundError(...)
```

`games` *is* populated for legacy seasons, so the guard passes and then every payload dataset uploads alongside it. Net effect: each of those four tags advertises ten seasons of coverage where three exist, and a consumer asking for 2019 gets an empty frame with no error rather than a clear absence.

## The fix

Guard per dataset rather than per season: still build locally (the empty-frame-with-schema contract is deliberate and `test_build_all_legacy_season` still asserts it), but skip the upload and log why.

## Verification

`test_legacy_season_does_not_publish_the_empty_capture_only_families` pins it, and it is a genuine red-green — with the fix reverted it fails, and the run logs the defect verbatim:

```
wrote ...situational_stats_2015.parquet (700B), 0 rows x 6 cols ... (release)
```

106 passed, ruff clean.

## Follow-up

This stops the 28 assets being **re-created**. Deleting the ones already published is a separate, destructive step and is not in this PR — it should happen after this merges, or they simply come back on the next run.

## Summary by Sourcery

Stop publishing schema-only NCAA baseball payload datasets when a build produces no rows for the requested season.

Bug Fixes:
- Prevent empty capture-era NCAA baseball datasets from being published for seasons where they contain zero rows.

Enhancements:
- Retain local generation of empty datasets while logging that they are outside the dataset capture era.

Tests:
- Add regression coverage confirming empty legacy-season families are not released while populated datasets continue to publish.